### PR TITLE
postgres.rb: upgrade to v9.4.5.0

### DIFF
--- a/Casks/postgres.rb
+++ b/Casks/postgres.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'postgres' do
-  version '9.4.4.1'
-  sha256 '16647ae93735005ba0d386229b4cec1bc0dd9cb5f487a886c9e71e6153b5df1a'
+  version '9.4.5.0'
+  sha256 'ce3018430d7a783b2211c153aa9d7ab6197a39356668b516b9086fd0b5084e6a'
 
   # github.com is the official download host per the vendor homepage
   url "https://github.com/PostgresApp/PostgresApp/releases/download/#{version}/Postgres-#{version}.zip"


### PR DESCRIPTION
Update PostgresApp to 9.4.5.0

Includes security fixes: CVE-2015-5289, CVE-2015-5288

See documentations for detail
- https://github.com/PostgresApp/PostgresApp/releases/tag/9.4.5.0
- http://www.postgresql.org/docs/9.4/static/release-9-4-5.html